### PR TITLE
Query: fix caching length

### DIFF
--- a/.github/files/php-linting-phpcs.xml
+++ b/.github/files/php-linting-phpcs.xml
@@ -13,4 +13,7 @@
 	<rule ref="PHPCompatibilityWP">
 		<exclude name="PHPCompatibility"/>
 	</rule>
+
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/wordpress/*</exclude-pattern>
 </ruleset>

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,18 +52,17 @@ jobs:
           which jq
           jq --version
 
-      # On WP 5.2, PHPUnit 5.x, 6.x and 7.x are supported.
       # On PHP >= 8.0, PHPUnit 7.5+ is needed, no matter what.
       - name: Determine supported PHPUnit version
         id: set_phpunit
         run: |
-          if [[ "matrix.php-versions" > "7.4" ]]; then
-            echo '::set-output name=PHPUNIT::7.5.*'
+          if [[ "matrix.php-versions" > "8.0" ]]; then
+            echo '::set-output name=PHPUNIT::"phpunit/phpunit=7.5.*" --ignore-platform-reqs'
           else
-            echo '::set-output name=PHPUNIT::5.7.*||6.5.*||7.5.*'
+            echo '::set-output name=PHPUNIT::"phpunit/phpunit=5.7.* || 6.5.* || 7.5.*"'
           fi
       - name: 'Composer: set up PHPUnit'
-        run: composer require --no-update phpunit/phpunit:"${{ steps.set_phpunit.outputs.PHPUNIT }}"
+        run: composer global require ${{ steps.set_phpunit.outputs.PHPUNIT }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,18 +52,6 @@ jobs:
           which jq
           jq --version
 
-      # On PHP >= 8.0, PHPUnit 7.5+ is needed, no matter what.
-      - name: Determine supported PHPUnit version
-        id: set_phpunit
-        run: |
-          if [[ "matrix.php-versions" > "8.0" ]]; then
-            echo '::set-output name=PHPUNIT::"phpunit/phpunit=7.5.*" --ignore-platform-reqs'
-          else
-            echo '::set-output name=PHPUNIT::"phpunit/phpunit=5.7.* || 6.5.* || 7.5.*"'
-          fi
-      - name: 'Composer: set up PHPUnit'
-        run: composer global require ${{ steps.set_phpunit.outputs.PHPUNIT }}
-
       - name: Install dependencies
         run: |
           # Install stuff ignoring platform reqs.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.1', '7.4', '8.0' ]
+        php-versions: [ '7.4', '8.0' ]
         experimental: [ false ]
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,19 @@ jobs:
           which jq
           jq --version
 
+      # On WP 5.2, PHPUnit 5.x, 6.x and 7.x are supported.
+      # On PHP >= 8.0, PHPUnit 7.5+ is needed, no matter what.
+      - name: Determine supported PHPUnit version
+        id: set_phpunit
+        run: |
+          if [[ "matrix.php-versions" > "7.4" ]]; then
+            echo '::set-output name=PHPUNIT::7.5.*'
+          else
+            echo '::set-output name=PHPUNIT::5.7.*||6.5.*||7.5.*'
+          fi
+      - name: 'Composer: set up PHPUnit'
+        run: composer require --no-update phpunit/phpunit:"${{ steps.set_phpunit.outputs.PHPUNIT }}"
+
       - name: Install dependencies
         run: |
           # Install stuff ignoring platform reqs.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Unit Tests
 
-on:
-  # Run on all pushes and on all pull requests.
-  push:
-  pull_request:
+on: pull_request
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Unit Tests
+
+on:
+  # Run on all pushes and on all pull requests.
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: "PHPUnit ${{ matrix.php }} - WP ${{ matrix.wp }}"
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 3  # Successful runs seem to take ~1 minute
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: [ '7.4', '8.0' ]
+        experimental: [ false ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: composer
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Use composer cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Tool versions
+        run: |
+          which php
+          php --version
+          which composer
+          composer --version
+          which jq
+          jq --version
+
+      - name: Install dependencies
+        run: |
+          # Install stuff ignoring platform reqs.
+          composer install --ignore-platform-reqs
+          # Remove stuff we don't need here that fails some platform reqs.
+          # This will complain if we missed any.
+          composer remove --dev automattic/jetpack-codesniffer
+
+      - name: Run the unit tests
+        run: |
+          composer test-php

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: "PHPUnit ${{ matrix.php }} - WP ${{ matrix.wp }}"
+    name: PHPUnit (${{ matrix.php-versions }})
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 3  # Successful runs seem to take ~1 minute

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,4 +34,5 @@
 	<!-- Ignore external libraries -->
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/wordpress/*</exclude-pattern>
 </ruleset>

--- a/composer.lock
+++ b/composer.lock
@@ -1598,15 +1598,15 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "5.7",
+            "version": "5.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "5.7"
+                "reference": "5.7.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.7"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.7.1"
             },
             "require": {
                 "php": ">=5.3.2",
@@ -1649,7 +1649,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-03-09T20:23:15+00:00"
+            "time": "2021-04-15T02:11:19+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",

--- a/posts-on-this-day.php
+++ b/posts-on-this-day.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jeremy.hu/my-plugins/posts-on-this-day/
  * Description: Widget to display a list of posts published "on this day" in years past. A good little bit of nostalgia for your blog.
  * Author: Jeremy Herve
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author URI: https://jeremy.hu
  * License: GPL2+
  * Text Domain: posts-on-this-day

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Posts On This Day ===
 Contributors: jeherve
 Tags: widget, on this day
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 Requires at least: 5.6
 Requires PHP: 7.1
 Tested up to: 5.7
@@ -45,6 +45,10 @@ You have 2 ways to do so.
 1. Widget settings
 
 == Changelog ==
+
+### [1.5.2] - 2021-04-15
+
+* Caching: cache data until midnight of the same day, instead of caching it for 24 hours.
 
 ### [1.5.1] - 2021-04-13
 

--- a/src/class-posts-on-this-day-widget.php
+++ b/src/class-posts-on-this-day-widget.php
@@ -262,7 +262,7 @@ class Posts_On_This_Day_Widget extends WP_Widget {
 			esc_html__( 'Are you only interested in posts that were published on that exact day?', 'posts-on-this-day' ),
 			esc_attr( $this->get_field_name( 'exact_match' ) ),
 			checked( $instance['exact_match'], 1, false ),
-			esc_html__( 'By default, the widget will look for posts that were published around that day (within a week) in years past.', 'jetpack' )
+			esc_html__( 'By default, the widget will look for posts that were published around that day (within a week) in years past.', 'posts-on-this-day' )
 		);
 	}
 } // Class Posts_On_This_Day_Widget

--- a/tests/src/class-test-query.php
+++ b/tests/src/class-test-query.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Tests for Jeherve\Posts_On_This_Day\Query;
+ *
+ * @package jeherve/posts-on-this-day
+ */
+
+namespace Jeherve\Posts_On_This_Day;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Test_Query
+ */
+class Test_Query extends BaseTestCase {
+	/**
+	 * Test the output of the get_seconds_left_in_day method.
+	 *
+	 * @covers Jeherve\Posts_On_This_Day\Query::get_seconds_left_in_day
+	 */
+	public function test_get_seconds_left_in_day() {
+
+		$seconds_remaining = Query::get_seconds_left_in_day();
+
+		$this->assertGreaterThan( 0, $seconds_remaining );
+		$this->assertLessThanOrEqual( DAY_IN_SECONDS, $seconds_remaining );
+	}
+}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

﻿- Update composer.lock with newer version of WP
- Add new method to fetch the number of seconds left in the day
- Add tests for new method

This was brought up in this thread:
https://wordpress.org/support/topic/time-zone-35/

The new method allows us to cache our data not for 24 hours, but for as many hours as there are left in the day.
This way, if the first visitor on the site on a given day visits the site at 11AM, we do not cache the posts until 11AM the next day. Instead we cache them until midnight on that day.
