### PR TITLE
Actions: add triage action

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Tell me everything. Is the sky falling on your head, or is it just a bug in the code?
+labels: [ '[Type] Bug' ]
+body:
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        ...
+    validations:
+      required: true
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Severity
+      description: How many users are impacted? A guess is fine.
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+  - type: textarea
+    id: workarounds-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
+      placeholder: |
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.

--- a/.github/actions/triage/action.yml
+++ b/.github/actions/triage/action.yml
@@ -1,0 +1,18 @@
+name: "Issue Triage"
+description: "Automatically add labels on newly opened issues"
+inputs:
+  github_token:
+    description: "GitHub access token"
+    required: true
+    default: ${{ github.token }}
+  triage_projects_token:
+    description: "Triage Projects access token"
+    required: false
+    default: ""
+  triage_projects_board:
+    description: "Triage Projects board URL"
+    required: false
+    default: ""
+runs:
+  using: node16
+  main: "dist/index.js"

--- a/.github/actions/triage/package.json
+++ b/.github/actions/triage/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "triage",
+	"version": "1.0.0",
+	"description": "A GitHub action to automatically add labels on newly opened issues.",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"build": "ncc build src/index.js -o dist --source-map"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jeherve/test-actions.git"
+	},
+	"keywords": [
+		"github",
+		"action",
+		"octokit"
+	],
+	"author": "Jeremy Herve",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/jeherve/test-actions/issues"
+	},
+	"homepage": "https://github.com/jeherve/test-actions#readme",
+	"devDependencies": {
+		"@vercel/ncc": "^0.34.0"
+	},
+	"dependencies": {
+		"@actions/core": "^1.9.0",
+		"@actions/github": "^5.0.3"
+	},
+	"engines": {
+		"node": "16.16.0"
+	}
+}

--- a/.github/actions/triage/src/index.js
+++ b/.github/actions/triage/src/index.js
@@ -1,0 +1,96 @@
+const { setFailed, getInput, debug } = require( '@actions/core' );
+const { context, getOctokit } = require( '@actions/github' );
+const triagePrToProject = require( './triage-pr-to-project' );
+
+/**
+ * Determine the priority of the issue based on severity and workarounds info from the issue contents.
+ * This uses the priority matrix defined in this post: https://jeremy.hu/github-actions-build-javascript-action-part-2/
+ *
+ * @param {string} severity - How many users are impacted by the problem.
+ * @param {string} workaround - Are there any available workarounds for the problem.
+ * @returns {string} Priority of issue. High, Medium, Low, or empty string.
+ */
+function definePriority( severity = '', workaround = '' ) {
+	const labels = {
+		high: '🏔 High',
+		medium: '🏕 Medium',
+		low: '🏝 Low',
+	};
+	const { high, medium, low } = labels;
+
+	if ( workaround === 'No and the platform is unusable' ) {
+		return severity === 'One' ? medium : high;
+	} else if ( workaround === 'No but the platform is still usable' ) {
+		return medium;
+	} else if ( workaround !== '' && workaround !== '_No response_' ) { // "_No response_" is the default value.
+		return severity === 'All' || severity === 'Most (> 50%)' ? medium : low;
+	}
+
+	// Fallback.
+	return '';
+}
+
+( async function main() {
+	debug( 'Our action is running' );
+
+	const token = getInput( 'github_token' );
+	if ( ! token ) {
+		setFailed( 'Input `github_token` is required' );
+		return;
+	}
+
+	// Get the Octokit client.
+	const octokit = new getOctokit( token );
+
+	// Get info about the event.
+	const { payload, eventName } = context;
+
+	debug( `Received event = '${ eventName }', action = '${ payload.action }'` );
+
+	// Let's monitor changes to Pull Requests.
+	const projectToken = getInput( 'triage_projects_token' );
+
+	if ( eventName === 'pull_request_target' && projectToken !== '' ) {
+		debug( `Triage: now processing a change to a Pull Request` );
+
+		// For this task, we need octokit to have extra permissions not provided by the default GitHub token.
+		// Let's create a new octokit instance using our own custom token.
+		const projectOctokit = new getOctokit( projectToken );
+		await triagePrToProject( payload, projectOctokit );
+	}
+
+	// We only want to proceed if this is a newly opened issue.
+	if ( eventName === 'issues' && payload.action === 'opened' ) {
+		// Extra data from the event, to use in API requests.
+		const { issue: { number, body }, repository: { owner, name } } = payload;
+
+		// List of labels to add to the issue.
+		const labels = [ 'Issue triaged' ];
+
+		// Look for priority indicators in body.
+		const priorityRegex = /###\sSeverity\n\n(?<severity>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<workaround>.*)\n/gm;
+		let match;
+		while ( ( match = priorityRegex.exec( body ) ) ) {
+			const [ , severity = '', workaround = '' ] = match;
+
+			const priorityLabel = definePriority( severity, workaround );
+			if ( priorityLabel !== '' ) {
+				labels.push( priorityLabel );
+			}
+		}
+
+		debug(
+			`Add the following labels to issue #${ number }: ${ labels
+				.map( ( label ) => `"${ label }"` )
+				.join( ', ' ) }`
+		);
+
+		// Finally make the API request.
+		await octokit.rest.issues.addLabels( {
+			owner: owner.login,
+			repo: name,
+			issue_number: number,
+			labels,
+		} );
+	}
+} )();

--- a/.github/actions/triage/src/triage-pr-to-project.js
+++ b/.github/actions/triage/src/triage-pr-to-project.js
@@ -1,0 +1,231 @@
+const { setFailed, getInput, debug } = require( '@actions/core' );
+
+/* global WebhookPayloadPullRequest, GitHub */
+
+/**
+ * Get Information about a project board.
+ *
+ * @param {GitHub} octokit          - Initialized Octokit REST client.
+ * @param {string} projectBoardLink - The link to the project board.
+ * @returns {Promise<Object>} - Project board information.
+ */
+async function getProjectDetails( octokit, projectBoardLink ) {
+	const projectRegex = /^(?:https:\/\/)?github\.com\/(?<ownerType>orgs|users)\/(?<ownerName>[^/]+)\/projects\/(?<projectNumber>\d+)/;
+	const matches = projectBoardLink.match( projectRegex );
+	if ( ! matches ) {
+		debug( `Triage: Invalid project board link provided. Cannot triage to a board` );
+		return {};
+	}
+
+	const {
+		groups: { ownerType, ownerName, projectNumber },
+	} = matches;
+
+	const projectInfo = {
+		ownerType: ownerType === 'orgs' ? 'organization' : 'user', // GitHub API requests require 'organization' or 'user'.
+		ownerName,
+		projectNumber: parseInt( projectNumber, 10 ),
+	};
+
+	// First, use the GraphQL API to request the project's node ID,
+	// as well as info about the first 20 fields for that project.
+	const projectDetails = await octokit.graphql(
+		`query getProject($ownerName: String!, $projectNumber: Int!) {
+			${ projectInfo.ownerType }(login: $ownerName) {
+				projectV2(number: $projectNumber) {
+					id
+					fields(first:20) {
+						nodes {
+							... on ProjectV2Field {
+								id
+								name
+							}
+							... on ProjectV2SingleSelectField {
+								id
+								name
+								options {
+									id
+									name
+								}
+							}
+						}
+					}
+				}
+			}
+		}`,
+		{
+			ownerName: projectInfo.ownerName,
+			projectNumber: projectInfo.projectNumber,
+		}
+	);
+
+	// Extract the project node ID.
+	const projectNodeId = projectDetails[ projectInfo.ownerType ]?.projectV2.id;
+	if ( projectNodeId ) {
+		projectInfo.projectNodeId = projectNodeId; // Project board node ID. String.
+	}
+
+	// Extract the ID of the Status field.
+	const statusField = projectDetails[ projectInfo.ownerType ]?.projectV2.fields.nodes.find(
+		field => field.name === 'Status'
+	);
+	if ( statusField ) {
+		projectInfo.status = statusField; // Info about our status column (id as well as possible values).
+	}
+
+	return projectInfo;
+}
+
+/**
+ * Set custom fields for a project item.
+ *
+ * @param {GitHub} octokit       - Initialized Octokit REST client.
+ * @param {Object} projectInfo   - Info about our project board.
+ * @param {string} projectItemId - The ID of the project item.
+ * @param {string} statusText    - Status of our PR (must match an existing column in the project board).
+ * @returns {Promise<string>} - The new project item id.
+ */
+async function setPriorityField( octokit, projectInfo, projectItemId, statusText ) {
+	const {
+		projectNodeId, // Project board node ID.
+		status: {
+			id: statusFieldId, // ID of the status field.
+			options,
+		},
+	} = projectInfo;
+
+	// Find the ID of the status option that matches our PR status.
+	const statusOptionId = options.find( option => option.name === statusText ).id;
+	if ( ! statusOptionId ) {
+		debug(
+			`Triage: Status ${ statusText } does not exist as a colunm option in the project board.`
+		);
+		return '';
+	}
+
+	const projectNewItemDetails = await octokit.graphql(
+		`mutation ( $input: UpdateProjectV2ItemFieldValueInput! ) {
+			set_status: updateProjectV2ItemFieldValue( input: $input ) {
+				projectV2Item {
+					id
+				}
+			}
+		}`,
+		{
+			input: {
+				projectId: projectNodeId,
+				itemId: projectItemId,
+				fieldId: statusFieldId,
+				value: {
+					singleSelectOptionId: statusOptionId,
+				},
+			},
+		}
+	);
+
+	const newProjectItemId = projectNewItemDetails.set_status.projectV2Item.id;
+	if ( ! newProjectItemId ) {
+		debug( `Triage: Failed to set the "${ statusText }" status for this project item.` );
+		return '';
+	}
+
+	debug( `Triage: Project item ${ newProjectItemId } was moved to "${ statusText }" status.` );
+
+	return newProjectItemId; // New Project item ID (what we just edited). String.
+}
+
+/**
+ * Add PR to our project board.
+ *
+ * @param {GitHub} octokit     - Initialized Octokit REST client.
+ * @param {Object} projectInfo - Info about our project board.
+ * @param {string} node_id     - The node_id of the Pull Request.
+ * @returns {Promise<string>} - Info about the project item id that was created.
+ */
+async function addPrToBoard( octokit, projectInfo, node_id ) {
+	const { projectNodeId } = projectInfo;
+
+	// Add our PR to that project board.
+	const projectItemDetails = await octokit.graphql(
+		`mutation addIssueToProject($input: AddProjectV2ItemByIdInput!) {
+			addProjectV2ItemById(input: $input) {
+				item {
+					id
+				}
+			}
+		}`,
+		{
+			input: {
+				projectId: projectNodeId,
+				contentId: node_id,
+			},
+		}
+	);
+
+	const projectItemId = projectItemDetails.addProjectV2ItemById.item.id;
+	if ( ! projectItemId ) {
+		debug( `Triage: Failed to add PR to project board.` );
+		return '';
+	}
+
+	debug( `Triage: Added PR to project board.` );
+
+	return projectItemId;
+}
+
+/**
+ * Handle automatic triage of Pull Requests into a Github Project board.
+ *
+ * @param {WebhookPayloadPullRequest} payload - The payload from the Github Action.
+ * @param {GitHub}                    octokit - Initialized Octokit REST client.
+ * @returns {Promise<void>}
+ */
+async function triagePrToProject( payload, octokit ) {
+	// Extra data from the event, to use in API requests.
+	const {
+		pull_request: { number, draft, node_id },
+	} = payload;
+	const isDraft = !! draft;
+
+	const projectBoardLink = getInput( 'triage_projects_board' );
+	if ( ! projectBoardLink ) {
+		setFailed( 'Triage: No project board link provided. Cannot triage to a board' );
+		return;
+	}
+
+	// Get details about our project board, to use in our requests.
+	const projectInfo = await getProjectDetails( octokit, projectBoardLink );
+	if ( Object.keys( projectInfo ).length === 0 || ! projectInfo.projectNodeId ) {
+		setFailed( 'Triage: we cannot fetch info about our project board. Cannot triage to a board' );
+		return;
+	}
+
+	// Add our Pull Request to the project board.
+	const projectItemId = await addPrToBoard( octokit, projectInfo, node_id );
+	if ( ! projectItemId ) {
+		setFailed( 'Triage: failed to add PR to project board' );
+		return;
+	}
+
+	// If we have no info about the status column, stop.
+	if ( ! projectInfo.status ) {
+		debug( `Triage: No status column found in project board.` );
+		return;
+	}
+
+	// If a PR is opened but not ready for review yet, add it to the In Progress column.
+	if ( isDraft ) {
+		debug( `Triage: Pull Request #${ number } is a draft. Add it to the In Progress column.` );
+		await setPriorityField( octokit, projectInfo, projectItemId, 'In Progress' );
+		return;
+	}
+
+	// If the PR is ready for review, let's add it to the Needs Review column.
+	debug(
+		`Triage: Pull Request #${ number } is ready for review. Add it to the Needs Review column.`
+	);
+	await setPriorityField( octokit, projectInfo, projectItemId, 'Needs Review' );
+	return;
+}
+
+module.exports = triagePrToProject;

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,36 @@
+name: Triage
+on:
+  issues: # For auto-triage of issues.
+    types: [opened]
+  pull_request_target: # For triaging PRs into project boards.
+    types: [opened,converted_to_draft,ready_for_review]
+
+jobs:
+  issue-triage:
+    name: Apply some labels on newly opened issues
+    runs-on: ubuntu-latest
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v3
+
+     - name: Setup Node
+       uses: actions/setup-node@v3
+       with:
+          node-version: lts/*
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: Build Action
+       run: |
+          npm install && npm run build
+       working-directory: ./.github/actions/triage/
+
+     - name: Run action
+       uses: ./.github/actions/triage/
+       with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        triage_projects_token: ${{ secrets.TRIAGE_PROJECTS_TOKEN }}
+        triage_projects_board: https://github.com/users/jeherve/projects/2/


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

See my series of posts on this topic:

- https://jeremy.hu/github-actions-build-javascript-action-part-1/
- https://jeremy.hu/github-actions-build-javascript-action-part-2/

This is the action as of part 3. It does a few things:

- Label new issues based on severity information in an issue form.
- Move PRs to a project board and add to a custom status column there based on the status of the PR


#### Testing instructions:

This will need to be merged before it can be tested.
