### PR TITLE
Query: don't include private and password-protected posts

### DIFF
--- a/posts-on-this-day.php
+++ b/posts-on-this-day.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jeremy.hu/my-plugins/posts-on-this-day/
  * Description: Widget to display a list of posts published "on this day" in years past. A good little bit of nostalgia for your blog.
  * Author: Jeremy Herve
- * Version: 1.5.3
+ * Version: 1.5.4
  * Author URI: https://jeremy.hu
  * License: GPL2+
  * Text Domain: posts-on-this-day

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Posts On This Day ===
 Contributors: jeherve
 Tags: widget, on this day
-Stable tag: 1.5.3
+Stable tag: 1.5.4
 Requires at least: 5.6
 Requires PHP: 7.1
 Tested up to: 6.2
@@ -45,6 +45,10 @@ You have 2 ways to do so.
 1. Widget settings
 
 == Changelog ==
+
+### [1.5.4] - 2023-04-27
+
+* Query: do not display private and password-protected posts in the widget.
 
 ### [1.5.3] - 2021-08-06
 

--- a/src/class-query.php
+++ b/src/class-query.php
@@ -117,6 +117,8 @@ class Query {
 			'post_type'      => $instance['post_types'],
 			'posts_per_page' => $instance['max'],
 			'date_query'     => $date_query,
+			'has_password'   => false,
+			'post_status'    => 'publish',
 		);
 
 		/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Folks who want those types of posts shown can always use the `jeherve_posts_on_this_day_query_args` filter to remove the 2 ags (`has_password` and `post_status`) from the query.

This was reported here:
https://wordpress.org/support/topic/exclude-private-password-protected-posts/

#### Testing instructions:

* You'll need a site with multiple posts, some in the past year, all public.
* Verify that the posts appear in the widget.
* Now edit one of those past posts so it's pasword-protected.
* After saving your changes, verify that it doesn't appear in the widget anymore.
* Now edit it to be private
* Verify that it doesn't appear in the widget.
* Change it back to public.
* Verify that it appears again.
