### PR TITLE
Widget: add a new filter to customize display of year.

### DIFF
--- a/posts-on-this-day.php
+++ b/posts-on-this-day.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jeremy.hu/my-plugins/posts-on-this-day/
  * Description: Widget to display a list of posts published "on this day" in years past. A good little bit of nostalgia for your blog.
  * Author: Jeremy Herve
- * Version: 1.5.4
+ * Version: 1.5.5
  * Author URI: https://jeremy.hu
  * License: GPL2+
  * Text Domain: posts-on-this-day

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Posts On This Day ===
 Contributors: jeherve
 Tags: widget, on this day
-Stable tag: 1.5.4
+Stable tag: 1.5.5
 Requires at least: 5.6
 Requires PHP: 7.1
 Tested up to: 6.2
@@ -45,6 +45,10 @@ You have 2 ways to do so.
 1. Widget settings
 
 == Changelog ==
+
+### [1.5.5] - 2023-05-08
+
+* Widget: add a new filter, `jeherve_posts_on_this_day_widget_year_heading`, allowing one to customize the heading used to display years in the widget.
 
 ### [1.5.4] - 2023-04-27
 

--- a/src/class-posts-on-this-day-widget.php
+++ b/src/class-posts-on-this-day-widget.php
@@ -80,7 +80,23 @@ class Posts_On_This_Day_Widget extends WP_Widget {
 
 			foreach ( $posts as $year => $ids ) {
 				if ( $instance['group_by_year'] ) {
-					echo '<h4 class="posts_on_this_day__year">' . esc_html( $year ) . '</h4>';
+					/**
+					 * Filters the heading level for the year heading in the Posts On This Day widget.
+					 *
+					 * @since 1.5.5
+					 *
+					 * @param string $year_heading Heading level. Default to h4.
+					 */
+					$year_heading = apply_filters(
+						'jeherve_posts_on_this_day_widget_year_heading',
+						'h4'
+					);
+					printf(
+						'<%1$s class="posts_on_this_day__year">%2$s</%1$s>',
+						esc_attr( $year_heading ),
+						esc_html( $year ),
+					);
+
 					foreach ( $ids as $id ) {
 						echo $display->display_post( $id, $instance ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					}

--- a/src/class-posts-on-this-day-widget.php
+++ b/src/class-posts-on-this-day-widget.php
@@ -94,7 +94,7 @@ class Posts_On_This_Day_Widget extends WP_Widget {
 					printf(
 						'<%1$s class="posts_on_this_day__year">%2$s</%1$s>',
 						esc_attr( $year_heading ),
-						esc_html( $year ),
+						esc_html( $year )
 					);
 
 					foreach ( $ids as $id ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This new filter will allow folks to customize the way the year is displayed in the widget. It currently uses an `h4` heading, but using the filter you could change that to a different heading, or a different tag altogether like so:

```php
add_filter(
	'jeherve_posts_on_this_day_widget_year_heading',
	function () {
		return 'div';
	}
);
```

This was suggested here:
https://wordpress.org/support/topic/change-h4-to-div/

#### Testing instructions:

By default, that heading only appears when picking to group posts by year. Once you've done that, the display shouldn't change with or without this PR. However, if you add the snippet above the outcome should change like so:

**Before**
<img width="611" alt="Screenshot 2023-05-08 at 09 13 09" src="https://user-images.githubusercontent.com/426388/236760298-15ec16ee-ac42-46c1-9cd8-ff014044e6c8.png">

**After**

<img width="592" alt="Screenshot 2023-05-08 at 09 14 50" src="https://user-images.githubusercontent.com/426388/236760333-0157c68f-8611-4a77-a0ac-b7babbfba5da.png">
